### PR TITLE
APPL parameter should be MSFT to match test description

### DIFF
--- a/modules/ROOT/pages/bat-bdd-reference.adoc
+++ b/modules/ROOT/pages/bat-bdd-reference.adoc
@@ -241,7 +241,7 @@ describe `User trades stocks` in [
       POST `http://broker/sell_stocks` with {
         body: {
           quantity: 20,
-          paper: 'APPL'
+          paper: 'MSFT'
         }
       } assert [
         $.response.status == 201


### PR DESCRIPTION
As I was reading the docs I noticed this typo.