### PR TITLE
link not working on 'See Also' section

### DIFF
--- a/modules/ROOT/pages/afm-add-schedule.adoc
+++ b/modules/ROOT/pages/afm-add-schedule.adoc
@@ -45,4 +45,4 @@ The countdown to the first run of the selected test version begins.
 
 == See Also
 
-* xref:afm-public-versus-private.adoc[Differences in the Monitoring of Public and Private APIs
+* xref:afm-public-versus-private.adoc[Differences in the Monitoring of Public and Private APIs]


### PR DESCRIPTION
I just added a "]" at the end of the line.