### PR TITLE
Update note regarding raising maximum API Monitors

### DIFF
--- a/modules/ROOT/pages/afm-monitoring-public-apis.adoc
+++ b/modules/ROOT/pages/afm-monitoring-public-apis.adoc
@@ -44,7 +44,7 @@ Tests are run at fixed intervals that you define in schedules. Each test is asso
 
 Number of Schedules::
 +
-By default, AFM lets your organization in Anypoint Platform run up to five schedules for testing from public locations at one time. If you reach the limit of five schedules and want to run more monitors simultaneously, contact your MuleSoft administrator about raising your maximum.
+By default, AFM lets your organization in Anypoint Platform run up to five schedules for testing from public locations at one time. If you reach the limit of five schedules and want to run more monitors simultaneously, contact your MuleSoft Customer Success Manager about raising your maximum.
 
 You can also run monitors from private locations, if you have access to Anypoint Virtual Private Cloud. There is no limit to the number of schedules that you can create to use private locations. 
 


### PR DESCRIPTION
Currently, the note says to reach a MuleSoft administrator to raise that maximum, and it's not correct, as it's an entitlement that should manage the Customer Success Manager. This leads to customers creating Support cases when it doesn't apply.