### PR TITLE
Update afm-monitoring-private-apis.adoc

### DIFF
--- a/modules/ROOT/pages/afm-monitoring-private-apis.adoc
+++ b/modules/ROOT/pages/afm-monitoring-private-apis.adoc
@@ -19,7 +19,7 @@ You can also test public APIs by using private locations. Public APIs are APIs w
 
 Also, you can test private APIs from public locations if you whitelist the IP addresses of those locations. You might want to test a private API from a public location if you do not want to use vCores on testing private APIs or if you have no vCores available.
 
-In Runtime Manager, add a new rule to the firewall for Anypoint Virtual Private Cloud (Anypoint VPC). The type must be *https.port*, the source must be *Custom*, and the port range 8081. For the source, use an IP address from this list:
+In Runtime Manager, add a new rule to the firewall for Anypoint Virtual Private Cloud (Anypoint VPC). The type must be *http.port*, the source must be *Custom*, and the port range 8081. For the source, use an IP address from this list:
 
 [%header,cols=2*]
 |===


### PR DESCRIPTION
We went on a customer call with Mani Sundaram. It should be http.port not https.port.