### PR TITLE
220104-Added note on access shared secrets in Anypoint Secrets Manager

### DIFF
--- a/modules/ROOT/pages/bat-bdd-reference.adoc
+++ b/modules/ROOT/pages/bat-bdd-reference.adoc
@@ -88,6 +88,8 @@ A test suite must contain at least one test (.dwl) file.
 
 In your tests, you can access shared secrets in Anypoint Secrets Manager, which enables you to securely store sensitive information, such as a password, authentication token, endpoint URL, or webhook URL.
 
+Note: Currently only above mentioned shared resources we can access from Anypoint Secrets Manager, other resources are not supported (Eg: Certificate, etc).
+
 You create aliases for your shared secrets with the `bat grant` command. The BAT CLI stores aliases in your `bat.yaml` files in your test suites. You place aliases in your tests and, at runtime, the BAT CLI looks up the shared secrets by means of the aliases.
 
 [IMPORTANT]

--- a/modules/ROOT/pages/bat-bdd-reference.adoc
+++ b/modules/ROOT/pages/bat-bdd-reference.adoc
@@ -88,7 +88,7 @@ A test suite must contain at least one test (.dwl) file.
 
 In your tests, you can access shared secrets in Anypoint Secrets Manager, which enables you to securely store sensitive information, such as a password, authentication token, endpoint URL, or webhook URL.
 
-Note: Currently only above mentioned shared resources we can access from Anypoint Secrets Manager, other resources are not supported (Eg: Certificate, etc).
+NOTE: Anypoint Secrets Manager enables you to access only the above-mentioned shared resources. Other resources are not accessible.
 
 You create aliases for your shared secrets with the `bat grant` command. The BAT CLI stores aliases in your `bat.yaml` files in your test suites. You place aliases in your tests and, at runtime, the BAT CLI looks up the shared secrets by means of the aliases.
 


### PR DESCRIPTION
As confirmed by the engineering team (https://mulesoft.slack.com/archives/C8XR3MY4T/p1640857362031700) right now the only secret type we support is shared secrets/symmetric key as described in the documentation.